### PR TITLE
Refactor roles enum and add route guards

### DIFF
--- a/src/app/common/enums/index.ts
+++ b/src/app/common/enums/index.ts
@@ -3,6 +3,6 @@ export * from "./alert-panel-class.enum";
 export * from "./alert-type.enum";
 export * from "./breakpoints.enum";
 export * from "./pages-urls.enum";
-export * from "./rollsEnum";
+export * from "./rolesEnum";
 export * from "./routes-urls.enum";
 export * from "./svg-icons.enum";

--- a/src/app/common/enums/rolesEnum.ts
+++ b/src/app/common/enums/rolesEnum.ts
@@ -1,0 +1,10 @@
+/**
+ * Enum representing different user roles in the application.
+ * @author dgutierrez
+ */
+export enum RolesEnum {
+  SUPER_ADMIN = 'ROLE_SUPER_ADMIN',
+  MUNICIPAL_ADMIN = 'ROLE_MUNICIPAL_ADMIN',
+  VOLUNTEER_USER = 'ROLE_VOLUNTEER_USER',
+  COMMUNITY_USER = 'ROLE_COMMUNITY_USER'
+}

--- a/src/app/common/enums/rollsEnum.ts
+++ b/src/app/common/enums/rollsEnum.ts
@@ -1,9 +1,0 @@
-/**
- * Enum representing different user roles in the application.
- * @author dgutierrez
- */
-export enum RollsEnum {
-  ADMIN = 'ROLE_ADMIN',
-  USER = 'ROLE_USER',
-  SUPER_ADMIN = 'ROLE_SUPER_ADMIN'
-}

--- a/src/app/core/guards/admin-role.guard.ts
+++ b/src/app/core/guards/admin-role.guard.ts
@@ -1,0 +1,25 @@
+import { Injectable, inject } from "@angular/core";
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from "@angular/router";
+import {AuthHttpService} from '@services/http';
+import {RolesEnum} from '@common/enums';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AdminRoleGuard implements CanActivate {
+  private authHttpService = inject(AuthHttpService);
+  private router = inject(Router);
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): boolean {
+    const hasRole = this.authHttpService.hasRole(RolesEnum.MUNICIPAL_ADMIN) || this.authHttpService.hasRole(RolesEnum.SUPER_ADMIN);
+
+    if (!hasRole) {
+      this.router.navigate(['access-denied']);
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import {AuthHttpService} from '@services/http';
+import {PagesUrlsEnum} from '@common/enums';
+
+export const AuthGuard: CanActivateFn = (route, state) => {
+  const router = inject(Router);
+  const authService = inject(AuthHttpService);
+
+  if (authService.isAuthenticated()) return true;
+
+  router.navigate([PagesUrlsEnum.AUTH]);
+  return false;
+};

--- a/src/app/core/guards/guest.guard.ts
+++ b/src/app/core/guards/guest.guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import {AuthHttpService} from '@services/http';
+import {PagesUrlsEnum} from '@common/enums';
+
+export const GuestGuard: CanActivateFn = (route, state) => {
+  const router = inject(Router);
+  const authService = inject(AuthHttpService);
+
+  if (!authService.isAuthenticated()) return true;
+
+  router.navigate([PagesUrlsEnum.DASHBOARD]);
+  return false;
+};

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -2,7 +2,7 @@ import {Municipality} from './municipality';
 import {Interest} from './interest';
 import {Neighborhood} from './neighborhood';
 import {IAuthority} from '@common/interfaces/http';
-import {RollsEnum} from '@common/enums';
+import {RolesEnum} from '@common/enums';
 
 /**
  * User model representing a user in the system.
@@ -26,7 +26,7 @@ export class User {
   municipality: Municipality | null;
   neighborhood: Neighborhood | null;
   authorities: IAuthority[] | null;
-  role: RollsEnum | null;
+  role: RolesEnum | null;
 
   constructor(values: Partial<User> = {}) {
     this.id = values.id || null;

--- a/src/app/services/http/auth-http-service/auth-http.service.ts
+++ b/src/app/services/http/auth-http-service/auth-http.service.ts
@@ -4,7 +4,7 @@ import {HttpClient} from '@angular/common/http';
 import {Observable, tap} from 'rxjs';
 import {Constants} from '@common/constants/constants';
 import {ILoginResponse} from '@common/interfaces/http';
-import {RollsEnum} from '@common/enums';
+import {RolesEnum} from '@common/enums';
 import {StorageService} from '@services/general';
 import {User} from '@models';
 import {RegisterUserRequestDTO} from '@models/dto';
@@ -126,7 +126,7 @@ export class AuthHttpService {
    * @author dgutierrez
    */
   isSuperAdmin(): boolean {
-    return this.hasRole(RollsEnum.SUPER_ADMIN);
+    return this.hasRole(RolesEnum.SUPER_ADMIN);
   }
 
   /**
@@ -147,7 +147,7 @@ export class AuthHttpService {
    */
   areActionsAvailable(requiredAuthorities: string[]): boolean {
     const hasRequiredRole = requiredAuthorities.some(r => this.hasRole(r));
-    const isAdmin = this.hasRole(RollsEnum.ADMIN) || this.hasRole(RollsEnum.SUPER_ADMIN);
+    const isAdmin = this.hasRole(RolesEnum.MUNICIPAL_ADMIN) || this.hasRole(RolesEnum.SUPER_ADMIN);
     return hasRequiredRole && isAdmin;
   }
 }


### PR DESCRIPTION
This pull request introduces a significant refactor to replace the `RollsEnum` with a new `RolesEnum` across the application, enhancing clarity and aligning with updated role definitions. It also adds new route guards to manage access control based on authentication and user roles. Below is a summary of the most important changes:

### Enum Replacement and Refactor:
* [`src/app/common/enums/index.ts`](diffhunk://#diff-16cc7d1e3b72db7cab2b02c2aebcebcb9ebccc00e25edd5baaa37ca1728b5f4fL6-R6): Updated export statement to replace `RollsEnum` with `RolesEnum`.
* [`src/app/common/enums/rolesEnum.ts`](diffhunk://#diff-f87c7752c0e8fed1199b947e12c561ed60b0dbca671f7a9205b57502b3aee230R1-R10): Added a new `RolesEnum` defining updated roles such as `SUPER_ADMIN`, `MUNICIPAL_ADMIN`, `VOLUNTEER_USER`, and `COMMUNITY_USER`.
* [`src/app/common/enums/rollsEnum.ts`](diffhunk://#diff-2b3324ca3361b6d625f59a80465c524f8d552a1521d248cbdd2bd0903264edc2L1-L9): Removed the outdated `RollsEnum`.

### Route Guards for Access Control:
* [`src/app/core/guards/admin-role.guard.ts`](diffhunk://#diff-5a3d4151b83ce3edfd132f9ffb4358edced14835a85bea9425e17ba32500a116R1-R25): Introduced `AdminRoleGuard` to restrict access to routes based on `MUNICIPAL_ADMIN` and `SUPER_ADMIN` roles.
* [`src/app/core/guards/auth.guard.ts`](diffhunk://#diff-33efc171d82ce32d40b171e87dbec1e726baa554c6e73bb8fe64aabd724cc95cR1-R14): Added `AuthGuard` to ensure users are authenticated before accessing certain routes.
* [`src/app/core/guards/guest.guard.ts`](diffhunk://#diff-09a7c3bdefd07923de4ccc13e4a62c717e449f84947679d062125344be5cdc00R1-R14): Added `GuestGuard` to restrict authenticated users from accessing guest-only routes.

### Model and Service Updates:
* [`src/app/models/user.ts`](diffhunk://#diff-5533a09368ee4c2822d8c2b31f9c4b83ee656c8ea0dde79d46281b28448dc8f1L5-R5): Replaced `RollsEnum` with `RolesEnum` in the `User` model's `role` property. [[1]](diffhunk://#diff-5533a09368ee4c2822d8c2b31f9c4b83ee656c8ea0dde79d46281b28448dc8f1L5-R5) [[2]](diffhunk://#diff-5533a09368ee4c2822d8c2b31f9c4b83ee656c8ea0dde79d46281b28448dc8f1L29-R29)
* [`src/app/services/http/auth-http-service/auth-http.service.ts`](diffhunk://#diff-9461bbf1c2ff7e663aee11fcc507cdef485ae88f1d2675cc23969d5ecc0e929aL129-R129): Updated methods to use `RolesEnum` instead of `RollsEnum`, including `isSuperAdmin` and `areActionsAvailable`. [[1]](diffhunk://#diff-9461bbf1c2ff7e663aee11fcc507cdef485ae88f1d2675cc23969d5ecc0e929aL129-R129) [[2]](diffhunk://#diff-9461bbf1c2ff7e663aee11fcc507cdef485ae88f1d2675cc23969d5ecc0e929aL150-R150)Renamed RollsEnum to RolesEnum and updated all references accordingly. Added new route guards: AdminRoleGuard, AuthGuard, and GuestGuard for improved route protection. Updated user model and auth service to use the new RolesEnum and adjusted role checks for admin access.