### PR TITLE
Remove unused rolesListSelectedChange binding

### DIFF
--- a/src/app/pages/security/create-user/create-user.page.html
+++ b/src/app/pages/security/create-user/create-user.page.html
@@ -43,7 +43,6 @@
         [i18nService]="i18nService"
         [form]="userRegistrationFormService.formUserRoleSelector"
         [rolesListSelected]="userRegistrationFormService.rolesListSelected()"
-        (rolesListSelectedChange)="userRegistrationFormService.setRoles(userRegistrationFormService.formUserRoleSelector,$event)"
         [rolesList]="roleHttpService.roleList()"
       />
     </div>


### PR DESCRIPTION
This pull request includes a small change to the `create-user.page.html` file. The change removes the `(rolesListSelectedChange)` event binding, which previously updated roles in the `userRegistrationFormService` when the roles list selection changed.The (rolesListSelectedChange) event binding was removed from the user role selector component in create-user.page.html as it is no longer needed.