### PR TITLE
Remove language selection from navbar and default to Spanish

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -70,8 +70,9 @@ export class App {
       preferredLanguage.startsWith(lang.code)
     );
 
-    const languageCode = matchedLanguage ? matchedLanguage.code : LanguagesEnum.SPANISH;
-
+    //The default language is hardcoded to Spanish as per the request to remove the requirement.
+    //const languageCode = matchedLanguage ? matchedLanguage.code : LanguagesEnum.SPANISH;
+    const languageCode = LanguagesEnum.SPANISH; // Default to Spanish
     this.translateService.use(languageCode).subscribe(() => {
       this.i18nService.setPreferenceLanguage(this.i18nService.getPreferenceLanguageByCode(languageCode) || null);
       this.logService.debug({

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -7,9 +7,6 @@
     }
     <img class="ms-2 logo" src="logo.png" alt="Logo de la aplicacion"/>
     <div class="d-flex flex-grow-1 justify-content-end">
-      <button mat-icon-button [matMenuTriggerFor]="languageMenu">
-        <mat-icon class="icon-color-scheme">{{ i18n.currentLanguage()?.icon }}</mat-icon>
-      </button>
       <button mat-icon-button [matMenuTriggerFor]="themeMenu">
         <mat-icon class="icon-color-scheme">{{ theme.selectedTheme()?.icon }}</mat-icon>
       </button>
@@ -24,18 +21,6 @@
       >
         <mat-icon>{{ themeItem.icon }}</mat-icon>
         <span>{{ themeItem.label | translate }}</span>
-      </button>
-    }
-  </mat-menu>
-  <mat-menu #languageMenu>
-    @for (languageItem of i18n.supportedLanguages(); track languageItem.label) {
-      <button
-        [class.selected-language]="i18n.currentLanguage()?.label === languageItem.label"
-        mat-menu-item
-        (click)="i18n.setPreferenceLanguage(languageItem)"
-      >
-        <mat-icon>{{ languageItem.icon }}</mat-icon>
-        <span>{{ languageItem.label | translate }}</span>
       </button>
     }
   </mat-menu>


### PR DESCRIPTION
This pull request includes changes to simplify the application's language selection functionality by removing the language menu and hardcoding the default language to Spanish. Additionally, it updates the navbar component to reflect these changes.

### Language selection simplification:
* [`src/app/app.ts`](diffhunk://#diff-18f0b78b713daf3f4fc2d305926785508575bdc7f304363a64a3b3a2985b58beL73-R75): Removed the conditional logic for determining the default language based on the user's preferred language. The default language is now hardcoded to Spanish (`LanguagesEnum.SPANISH`).

### Navbar updates:
* [`src/app/components/navbar/navbar.component.html`](diffhunk://#diff-dd95d5ec525aeb440b592f7b20e89800b43ca61a146a6fd274442c3aa245b7f9L10-L12): Removed the language menu button and its associated functionality, including the `languageMenu` definition and the list of supported languages. [[1]](diffhunk://#diff-dd95d5ec525aeb440b592f7b20e89800b43ca61a146a6fd274442c3aa245b7f9L10-L12) [[2]](diffhunk://#diff-dd95d5ec525aeb440b592f7b20e89800b43ca61a146a6fd274442c3aa245b7f9L30-L41)Eliminated the language selection menu from the navbar UI and hardcoded the default language to Spanish in the app initialization logic, as requested. This simplifies language handling and removes user language preference selection.