### PR TITLE
Remove success alert after user update

### DIFF
--- a/src/app/pages/security/edit-user/edit-user.page.ts
+++ b/src/app/pages/security/edit-user/edit-user.page.ts
@@ -102,10 +102,6 @@ export class EditUserPage implements OnInit {
 
     this.userHttpService.update(updateUserRequest);
     this.router.navigate([PagesUrlsEnum.SECURITY_USER_MANAGEMENT])
-    this.alertService.displayAlert({
-      messageKey: this.i18nService.i18nPagesValidationsEnum.EDIT_USER_PAGE_USER_UPDATED_SUCCESSFULLY,
-      type: AlertTypeEnum.SUCCESS
-    })
   }
 
   /**


### PR DESCRIPTION
This pull request includes a small change to the `EditUserPage` class in `edit-user.page.ts`. The change removes the alert notification that was displayed after a user update operation.Deleted the display of a success alert message following user update in EditUserPage. Navigation to the user management page remains unchanged.