### PR TITLE
Remove env files from GitHub

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,0 @@
-NG_APP_API_URL=https://api.example.com
-NG_APP_ENV=development
-NG_APP_API_KEY_GOOGLE_MAPS=tu_api_key_aqui

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,0 @@
-NG_APP_API_URL=https://api.example.com
-NG_APP_ENV=production
-NG_APP_API_KEY_GOOGLE_MAPS=tu_api_key_aqui

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ Thumbs.db
 
 # GitIgnore End
 .env
+.env.development
+.env.production


### PR DESCRIPTION
This pull request removes unused environment variables from both the development and production `.env` files. These variables are no longer required and have been cleaned up to simplify the configuration.

* Cleanup of environment variables:
  * [`.env.development`](diffhunk://#diff-da4c41d59c967338247b2f0ea6d845ab05171f942fd9521b96d3304202185db9L1-L3): Removed `NG_APP_API_URL`, `NG_APP_ENV`, and `NG_APP_API_KEY_GOOGLE_MAPS` as they are no longer in use.
  * [`.env.production`](diffhunk://#diff-48f73ea2653e45c41f31afc2d42dfde14d8caf26d8dd24d3d2a81a52604f4cb6L1-L3): Removed `NG_APP_API_URL`, `NG_APP_ENV`, and `NG_APP_API_KEY_GOOGLE_MAPS` as they are no longer in use.