### PR TITLE
Add confirm action modal and admin complaint actions

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -325,7 +325,10 @@
     "rulesManagement": "Rules Management",
     "update": "Update",
     "updateNotificationRule": "Update Notification Rule",
-    "createAnimalDiagnosis": "Create diagnosis"
+    "createAnimalDiagnosis": "Create diagnosis",
+    "cancel": "Cancel",
+    "accept": "Accept",
+    "confirm": "Confirm"
   },
   "================== LOADING MESSAGES ==================": "",
   "loadingMessages": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -311,7 +311,7 @@
   "================== BUTTON TEXT ===========================": "",
   "buttons": {
     "alreadyHaveAnAccount": "¿Ya tiene una cuenta?",
-    "close": "Cerrar",
+    "cancel": "Cancelar",
     "closeSession": "Cerrar sesión",
     "completeProfile": "Completar perfil",
     "createMunicipality": "Crear municipalidad",
@@ -333,7 +333,10 @@
     "rulesManagement": "Gestión de reglas",
     "update": "Actualizar",
     "updateNotificationRule": "Actualizar regla de notificación",
-    "createAnimalDiagnosis": "Crear diagnóstico"
+    "createAnimalDiagnosis": "Crear diagnóstico",
+    "close": "Cerrar",
+    "accept": "Aceptar",
+    "confirm": "Confirmar"
   },
   "================== LOADING MESSAGES ==================": "",
   "loadingMessages": {

--- a/src/app/common/enums/i18n/i18n-buttons.enum.ts
+++ b/src/app/common/enums/i18n/i18n-buttons.enum.ts
@@ -7,6 +7,9 @@ export enum I18nButtonsEnum {
 
   BUTTON_ALREADY_HAVE_AN_ACCOUNT = I18nButtonsEnum.BUTTONS + "alreadyHaveAnAccount",
   BUTTON_CLOSE = I18nButtonsEnum.BUTTONS + "close",
+  BUTTON_CANCEL = I18nButtonsEnum.BUTTONS + "cancel",
+  BUTTON_ACCEPT = I18nButtonsEnum.BUTTONS + "accept",
+  BUTTON_CONFIRM = I18nButtonsEnum.BUTTONS + "confirm",
   BUTTON_CLOSE_SESSION = I18nButtonsEnum.BUTTONS + "closeSession",
   BUTTON_COMPLETE_PROFILE = I18nButtonsEnum.BUTTONS + "completeProfile",
   BUTTON_CREATE_MUNICIPALITY = I18nButtonsEnum.BUTTONS + "createMunicipality",

--- a/src/app/common/interfaces/modals/confirm-action-modal-data.interface.ts
+++ b/src/app/common/interfaces/modals/confirm-action-modal-data.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * Interface for the data passed to a confirm action modal.
+ * @author dgutierrez
+ */
+export interface IConfirmActionModalData {
+  title?: string;
+  message?: string;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  showCancelButton?: boolean;
+  matIconName?: string;
+}

--- a/src/app/common/interfaces/modals/confirmation-result.interface.ts
+++ b/src/app/common/interfaces/modals/confirmation-result.interface.ts
@@ -1,0 +1,7 @@
+/**
+ * Interface for the data response from a confirm action modal.
+ * @author dgutierrez
+ */
+export interface IConfirmationResult {
+  isConfirmed: boolean;
+}

--- a/src/app/common/interfaces/modals/index.ts
+++ b/src/app/common/interfaces/modals/index.ts
@@ -1,3 +1,5 @@
+export * from "./confirm-action-modal-data.interface";
+export * from "./confirmation-result.interface";
 export * from "./loading-modal-dialog-data.interface";
 export * from "./notifications-modal-dialog-data.interface";
 export * from "./viewer-picture-modal-dialog-data.interface";

--- a/src/app/components/forms/complaint/complaint-form/complaint-form.component.html
+++ b/src/app/components/forms/complaint/complaint-form/complaint-form.component.html
@@ -126,34 +126,54 @@
     }
 
     @if (mode() === 'edit') {
+      @if (
+        complaintStateDTO()?.id !== complaintStateIdEnum().CLOSED &&
+        complaintStateDTO()?.id !== complaintStateIdEnum().CANCELLED
+        ) {
 
-      @if (authHttpService().isCommunityUser()) {
-        @if (complaintStateDTO()?.id === complaintStateIdEnum().OPEN) {
-          <button class="me-3" matButton="tonal" (click)="onUpdate()">Actualizar denuncia</button>
-          <button matButton="outlined" (click)="onCancel()">Cancelar denuncia</button>
+        @if (authHttpService().isCommunityUser()) {
+          @if (complaintStateDTO()?.id === complaintStateIdEnum().OPEN) {
+            <button class="me-3" matButton="tonal" (click)="onUpdate()">Actualizar denuncia</button>
+            <button matButton="outlined" (click)="onCancel()">Cancelar denuncia</button>
+          }
+          @if (complaintStateDTO()?.id === complaintStateIdEnum().WITH_OBSERVATIONS) {
+            <button matButton="tonal" (click)="onResubmit()">Actualizar y reenviar</button>
+          }
         }
-        @if (complaintStateDTO()?.id === complaintStateIdEnum().WITH_OBSERVATIONS) {
-          <button matButton="tonal" (click)="onResubmit()">Actualizar y reenviar</button>
+
+        @if (authHttpService().isMunicipalityAdmin()) {
+
+          @if (
+            complaintStateDTO()?.id === complaintStateIdEnum().OPEN ||
+            complaintStateDTO()?.id === complaintStateIdEnum().WITH_OBSERVATIONS ||
+            complaintStateDTO()?.id === complaintStateIdEnum().APPROVED
+            ) {
+            <button class="me-3" matButton="outlined" (click)="onCancelByAdmin()">Cancelar denuncia</button>
+          }
+
+          @if (
+            complaintStateDTO()?.id === complaintStateIdEnum().OPEN ||
+            complaintStateDTO()?.id === complaintStateIdEnum().WITH_OBSERVATIONS ||
+            complaintStateDTO()?.id === complaintStateIdEnum().APPROVED ||
+            complaintStateDTO()?.id === complaintStateIdEnum().COMPLETED
+            ) {
+            <button class="me-3" matButton="outlined" (click)="onCloseByAdmin()">Cerrar denuncia</button>
+          }
+
+          @if (complaintStateDTO()?.id === complaintStateIdEnum().OPEN) {
+            <button class="me-3" matButton="filled" (click)="onWithObservations()">Con observaciones</button>
+            <button matButton="tonal" (click)="onApprove()">Aprobar</button>
+          }
+
+          @if (complaintStateDTO()?.id === complaintStateIdEnum().WITH_OBSERVATIONS) {
+            <button class="me-3" matButton="tonal" (click)="onWithObservations()">Con observaciones</button>
+          }
+
+          @if (complaintStateDTO()?.id === complaintStateIdEnum().APPROVED) {
+            <button matButton="tonal" (click)="onComplete()">Completar denuncia</button>
+          }
         }
       }
-
-      @if (authHttpService().isMunicipalityAdmin()) {
-        @if (complaintStateDTO()?.id === complaintStateIdEnum().OPEN) {
-          <button class="me-3" matButton="filled" (click)="onWithObservations()">Con observaciones</button>
-          <button matButton="tonal" (click)="onApprove()">Aprobar</button>
-        }
-        @if (complaintStateDTO()?.id === complaintStateIdEnum().WITH_OBSERVATIONS) {
-          <button class="me-3" matButton="tonal" (click)="onWithObservations()">Con observaciones</button>
-          <button matButton="outlined" (click)="onClose()">Cerrar denuncia</button>
-        }
-        @if (complaintStateDTO()?.id === complaintStateIdEnum().APPROVED) {
-          <button matButton="tonal" (click)="onComplete()">Completar denuncia</button>
-        }
-        @if (complaintStateDTO()?.id === complaintStateIdEnum().COMPLETED) {
-          <button matButton="outlined" (click)="onClose()">Cerrar denuncia</button>
-        }
-      }
-
     }
   </div>
 </form>

--- a/src/app/components/forms/complaint/complaint-form/complaint-form.component.ts
+++ b/src/app/components/forms/complaint/complaint-form/complaint-form.component.ts
@@ -67,8 +67,18 @@ export class ComplaintFormComponent {
 
   readonly onViewImageChange = output<void>();
   readonly onSubmitChange = output<void>();
+  readonly onCancelByAdminChange = output<void>();
+  readonly onCloseByAdminChange = output<void>();
 
+  /**
+   * Effect to change the readonly state of form inputs based on the complaint state and user role.
+   * @author dgutierrez
+   */
   readonly changeReadonlyInputsWhenStateEffect = effect(() => {
+    // Es necesario tambien estar atento a los cambios del form porque ah se puede saber si ya esta disponible
+    // para proceder con la desactivacion de los controles
+    const form = this.form();
+    if (!form) return;
     const complaintStateId = this.complaintStateDTO()?.id;
     const complaintStateIdEnum = this.complaintStateIdEnum();
     if (complaintStateId === complaintStateIdEnum.CANCELLED || complaintStateId === complaintStateIdEnum.CLOSED) {
@@ -93,8 +103,6 @@ export class ComplaintFormComponent {
           this.disableObservationsControl();
           return
         }
-
-        this.disableAllControls()
       }
     }
   })
@@ -174,6 +182,22 @@ export class ComplaintFormComponent {
    */
   onClose(): void {
     this.closeComplaintChange.emit();
+  }
+
+  /**
+   * Method to handle the cancel by admin action.
+   * @author dgutierrez
+   */
+  onCancelByAdmin(): void {
+    this.onCancelByAdminChange.emit();
+  }
+
+  /**
+   * Method to handle the close by admin action.
+   * @author dgutierrez
+   */
+  onCloseByAdmin(): void {
+    this.onCloseByAdminChange.emit();
   }
 
   /**

--- a/src/app/components/modals/index.ts
+++ b/src/app/components/modals/index.ts
@@ -1,3 +1,4 @@
+export * from "./modal-confirm-action/modal-confirm-action.component";
 export * from "./modal-loading/modal-loading.component";
-export * from "./modal-viewer-picture-viewer/modal-viewer-picture-viewer.component";
 export * from "./modal-notifications/modal-notifications.component";
+export * from "./modal-viewer-picture-viewer/modal-viewer-picture-viewer.component";

--- a/src/app/components/modals/modal-confirm-action/modal-confirm-action.component.html
+++ b/src/app/components/modals/modal-confirm-action/modal-confirm-action.component.html
@@ -1,0 +1,25 @@
+<h2 mat-dialog-title class="mat-typography">
+  <span class="roboto">{{ title() }}</span>
+</h2>
+
+<mat-dialog-content>
+  <p>
+    {{ message() }}
+  </p>
+  <div class="text-center">
+    <mat-icon class="icon-100">
+      warning
+    </mat-icon>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  @if (showCancelButton()) {
+    <button matButton (click)="onCancel()" cdkFocusInitial>
+      {{ cancelButtonText() | translate }}
+    </button>
+  }
+  <button matButton (click)="onConfirm()">
+    {{ confirmButtonText() | translate }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/components/modals/modal-confirm-action/modal-confirm-action.component.spec.ts
+++ b/src/app/components/modals/modal-confirm-action/modal-confirm-action.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ModalConfirmActionComponent } from './modal-confirm-action.component';
+
+describe('ModalConfirmAction', () => {
+  let component: ModalConfirmActionComponent;
+  let fixture: ComponentFixture<ModalConfirmActionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ModalConfirmActionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ModalConfirmActionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/modals/modal-confirm-action/modal-confirm-action.component.ts
+++ b/src/app/components/modals/modal-confirm-action/modal-confirm-action.component.ts
@@ -1,0 +1,45 @@
+import {Component, inject, model} from '@angular/core';
+import {Constants} from '@common/constants/constants';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle
+} from '@angular/material/dialog';
+import {MatButton} from '@angular/material/button';
+import {IConfirmActionModalData, IConfirmationResult} from '@common/interfaces/modals';
+import {I18nService} from '@services/general';
+import {TranslatePipe} from '@ngx-translate/core';
+import {MatIcon} from '@angular/material/icon';
+
+/**
+ * Component for confirming actions in modals.
+ * @author dgutierrez
+ */
+@Component({
+  selector: 'app-modal-confirm-action-component',
+  imports: [MatDialogActions, MatDialogContent, MatDialogTitle, MatButton, TranslatePipe, MatIcon],
+  templateUrl: './modal-confirm-action.component.html',
+  styleUrl: './modal-confirm-action.component.scss',
+  changeDetection: Constants.changeDetectionStrategy
+})
+export class ModalConfirmActionComponent {
+  readonly dialogRef = inject<MatDialogRef<ModalConfirmActionComponent, IConfirmationResult>>(MatDialogRef);
+  readonly data = inject<IConfirmActionModalData>(MAT_DIALOG_DATA);
+  readonly i18nService = inject(I18nService);
+  readonly title = model<string>(this.data.title ?? "Estás seguro?");
+  readonly message = model<string>(this.data.message ?? "Esta acción no se puede deshacer.");
+  readonly confirmButtonText = model<string>(this.data.confirmButtonText ?? this.i18nService.i18nButtonsEnum.BUTTON_CONFIRM);
+  readonly cancelButtonText = model<string>(this.data.cancelButtonText ?? this.i18nService.i18nButtonsEnum.BUTTON_CANCEL);
+  readonly showCancelButton = model<boolean>(this.data.showCancelButton ?? true);
+  readonly matIconName = model<string>(this.data.matIconName ?? 'warning');
+
+  onCancel(){
+    this.dialogRef.close({isConfirmed: false});
+  }
+
+  onConfirm(){
+    this.dialogRef.close({isConfirmed: true});
+  }
+}

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -2,13 +2,13 @@
   <mat-toolbar-row>
     @if (showMenuToggle()){
       <button mat-icon-button (click)="matSidenav()?.toggle()">
-        <mat-icon class="icon-color-scheme">menu</mat-icon>
+        <mat-icon class="color-scheme">menu</mat-icon>
       </button>
     }
     <img class="ms-2 logo" src="logo.png" alt="Logo de la aplicacion"/>
     <div class="d-flex flex-grow-1 justify-content-end align-items-center">
       @if (authHttpService.isAuthenticated()) {
-        <span class="roboto me-3">
+        <span class="roboto me-3 color-scheme">
         {{authHttpService.fullNameCurrentUser()}}
       </span>
         <button
@@ -16,13 +16,13 @@
           [matBadge]="notificationHttpService.myUnreadCount()"
           [matBadgeHidden]="notificationHttpService.showMyUnreadBadge()"
           (click)="openNotificationsModal()">
-          <mat-icon class="icon-color-scheme">
+          <mat-icon class="color-scheme">
             notifications
           </mat-icon>
         </button>
       }
       <button mat-icon-button [matMenuTriggerFor]="themeMenu">
-        <mat-icon class="icon-color-scheme">{{ theme.selectedTheme()?.icon }}</mat-icon>
+        <mat-icon class="color-scheme">{{ theme.selectedTheme()?.icon }}</mat-icon>
       </button>
     </div>
   </mat-toolbar-row>

--- a/src/app/pages/complaint/complaint-create/complaint-create.page.ts
+++ b/src/app/pages/complaint/complaint-create/complaint-create.page.ts
@@ -61,7 +61,14 @@ export class ComplaintCreatePage implements OnInit {
    * Otherwise, triggers the complaint creation process.
    * @author dgutierrez
    */
-  onSubmit(): void {
+  async onSubmit(): Promise<void> {
+    const confirmAction = await this.modalService.openConfirmActionModal({
+      title: "Confirmar envío",
+      message: "¿Estás seguro de que deseas enviar esta denuncia?",
+    })
+
+    if (!confirmAction?.isConfirmed) return;
+
     if (this.complaintCreateForm.invalid) {
       this.formsService.markFormTouchedAndDirty(this.complaintCreateForm);
       this.alertService.displayAlert({

--- a/src/app/pages/complaint/complaint-list/complaint-list.page.ts
+++ b/src/app/pages/complaint/complaint-list/complaint-list.page.ts
@@ -14,24 +14,27 @@ import {GeneralContainerComponent} from '@components/layout';
 import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {PagesUrlsEnum} from '@common/enums';
-import {DatePipe} from '@angular/common';
 import {
   MatCell,
-  MatCellDef, MatColumnDef,
-  MatHeaderCell, MatHeaderCellDef,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
   MatHeaderRow,
-  MatHeaderRowDef, MatNoDataRow,
+  MatHeaderRowDef,
+  MatNoDataRow,
   MatRow,
-  MatRowDef, MatTable
+  MatRowDef,
+  MatTable
 } from '@angular/material/table';
 import {MatChip} from '@angular/material/chips';
-import {MatError, MatFormField, MatInput, MatLabel} from '@angular/material/input';
+import {MatError, MatFormField, MatLabel} from '@angular/material/input';
 import {ReactiveFormsModule, Validators} from '@angular/forms';
 import {StripHtmlPipe} from '@core/pipes';
 import {TranslatePipe} from '@ngx-translate/core';
 import {MatOption, MatSelect} from '@angular/material/select';
 import {MatPaginator, PageEvent} from '@angular/material/paginator';
-import {IHttpActionConfig, ISearchComplaint} from '@common/interfaces/http';
+import {ISearchComplaint} from '@common/interfaces/http';
 
 /**
  * @author dgutierrez
@@ -41,19 +44,20 @@ import {IHttpActionConfig, ISearchComplaint} from '@common/interfaces/http';
   imports: [
     GeneralContainerComponent,
     MatButton,
-    MatIcon,
-    DatePipe,
     MatCell,
     MatCellDef,
     MatChip,
+    MatColumnDef,
     MatError,
     MatFormField,
     MatHeaderCell,
+    MatHeaderCellDef,
     MatHeaderRow,
     MatHeaderRowDef,
+    MatIcon,
     MatIconButton,
-    MatInput,
     MatLabel,
+    MatNoDataRow,
     MatOption,
     MatPaginator,
     MatRow,
@@ -63,9 +67,6 @@ import {IHttpActionConfig, ISearchComplaint} from '@common/interfaces/http';
     ReactiveFormsModule,
     StripHtmlPipe,
     TranslatePipe,
-    MatColumnDef,
-    MatHeaderCellDef,
-    MatNoDataRow
   ],
   templateUrl: './complaint-list.page.html',
   styleUrl: './complaint-list.page.scss',

--- a/src/app/pages/complaint/complaint-manage/complaint-manage.page.html
+++ b/src/app/pages/complaint/complaint-manage/complaint-manage.page.html
@@ -31,4 +31,6 @@
   (resubmitComplaintChange)="onResubmitComplaint()"
   (updateComplaintChange)="onUpdateComplaint()"
   (withObservationsComplaintChange)="onWithObservationsComplaint()"
+  (onCancelByAdminChange)="onCancelComplaint()"
+  (onCloseByAdminChange)="onCloseComplaint()"
 />

--- a/src/app/services/http/complaint-http-service/complaint-http.service.ts
+++ b/src/app/services/http/complaint-http-service/complaint-http.service.ts
@@ -1,7 +1,7 @@
 import {computed, Injectable, signal} from '@angular/core';
 import {BaseHttpService} from '@services/http/base-http-service/base-http.service';
 import {Constants} from '@common/constants/constants';
-import {ComplaintDto, CreateComplaintMultipartDto, UpdateComplaintMultipartDto, ObservationsDto} from '@models/dto';
+import {ComplaintDto, CreateComplaintMultipartDto, ObservationsDto, UpdateComplaintMultipartDto} from '@models/dto';
 import {IHttpActionConfig, IResponse, ISearch, ISearchComplaint} from '@common/interfaces/http';
 import {finalize} from 'rxjs';
 import {AlertTypeEnum} from '@common/enums';
@@ -388,6 +388,62 @@ export class ComplaintHttpService extends BaseHttpService<ComplaintDto> {
         error: this.handleError({
           message: 'Error closing complaint.',
           context: `${this.constructor.name}#closeComplaint`
+        }),
+      });
+  }
+
+  /**
+   * Cancels a complaint as MUNICIPAL_ADMIN (forces state to CANCELLED).
+   * PUT /complaints/{id}/cancel
+   * @author dgutierrez
+   */
+  cancelComplaintAsAdmin(config: { id: number; handlers?: IHttpActionConfig }): void {
+    const {id, handlers} = config;
+    this.isLoading.set(true);
+    handlers?.showLoading?.();
+
+    this.http.put<IResponse<ComplaintDto>>(`${this.sourceUrl}/${id}/cancel/admin`, {})
+      .pipe(finalize(() => {
+        this.isLoading.set(false);
+        handlers?.hideLoading?.();
+      }))
+      .subscribe({
+        next: (res) => {
+          this.selectedComplaint.set(res.data);
+          this.alertService.displayAlert({type: AlertTypeEnum.SUCCESS, message: res.message});
+          handlers?.callback?.();
+        },
+        error: this.handleError({
+          message: 'Error cancelling complaint as admin.',
+          context: `${this.constructor.name}#cancelComplaintAsAdmin`
+        }),
+      });
+  }
+
+  /**
+   * Closes a complaint as MUNICIPAL_ADMIN (forces state to COMPLETED).
+   * PUT /complaints/{id}/close
+   * @author dgutierrez
+   */
+  closeComplaintAsAdmin(config: { id: number; handlers?: IHttpActionConfig }): void {
+    const {id, handlers} = config;
+    this.isLoading.set(true);
+    handlers?.showLoading?.();
+
+    this.http.put<IResponse<ComplaintDto>>(`${this.sourceUrl}/${id}/close`, {})
+      .pipe(finalize(() => {
+        this.isLoading.set(false);
+        handlers?.hideLoading?.();
+      }))
+      .subscribe({
+        next: (res) => {
+          this.selectedComplaint.set(res.data);
+          this.alertService.displayAlert({type: AlertTypeEnum.SUCCESS, message: res.message});
+          handlers?.callback?.();
+        },
+        error: this.handleError({
+          message: 'Error closing complaint as admin.',
+          context: `${this.constructor.name}#closeComplaintAsAdmin`
         }),
       });
   }

--- a/src/app/services/modals/modal-service/modal.service.ts
+++ b/src/app/services/modals/modal-service/modal.service.ts
@@ -1,14 +1,16 @@
-import {inject, Injectable} from '@angular/core';
+import {inject, Injectable, Signal} from '@angular/core';
 import {
+  IConfirmActionModalData, IConfirmationResult,
   INotificationsModalDialogData,
   IViewerPictureModalDialogData
 } from '@common/interfaces/modals';
 import {MatDialog} from '@angular/material/dialog';
 import {
   ModalViewerPictureViewerComponent,
-  ModalNotificationsComponent,
+  ModalNotificationsComponent, ModalConfirmActionComponent,
 } from '@components/modals';
 import {ModalDialogPanelClassEnum} from '@common/enums';
+import {firstValueFrom} from 'rxjs';
 
 /**
  * Service for managing modal dialogs in the application.
@@ -45,5 +47,25 @@ export class ModalService {
       disableClose: true,
       data: modalPropsDialogData
     });
+  }
+
+  /**
+   * Opens a confirmation action modal dialog with the provided properties.
+   * @param modalProps Properties to configure the confirmation action modal dialog.
+   * @returns A signal that resolves with the confirmation result when the modal is closed.
+   * @author dgutierrez
+   */
+  async openConfirmActionModal(modalProps: IConfirmActionModalData = {}): Promise<IConfirmationResult | undefined> {
+    const ref = this.dialog.open<
+      ModalConfirmActionComponent,
+      IConfirmActionModalData,
+      IConfirmationResult
+    >(ModalConfirmActionComponent, {
+      panelClass: ModalDialogPanelClassEnum.MODAL_DIALOG_PANEL_CLASS_MD,
+      disableClose: true,
+      data: modalProps,
+    });
+
+    return firstValueFrom(ref.afterClosed());
   }
 }

--- a/src/theme/basic.scss
+++ b/src/theme/basic.scss
@@ -89,3 +89,16 @@
     height: func.to-rem($px-size);
   }
 }
+
+@for $size from 16 through 200 {
+  .mat-icon.icon-#{$size} {
+    --size: #{$size}px;
+    font-size: var(--size);
+    width: 1em;
+    height: 1em;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/src/theme/general.scss
+++ b/src/theme/general.scss
@@ -7,7 +7,7 @@
 }
 
 @include mixins.light-mode {
-  .icon-color-scheme {
+  .color-scheme {
     color: map.get(theme.$primary-palette, 100);
   }
 }


### PR DESCRIPTION
Introduces a reusable confirm action modal component and supporting interfaces. Updates complaint management to require confirmation for key actions (approve, cancel, resubmit, observe, close, update) and adds admin-specific endpoints for canceling and closing complaints. Enhances i18n button labels, refines complaint form/admin controls, and updates theme/icon classes for consistency.